### PR TITLE
Fix for artists who only have HDClearlogos on fanart.tv

### DIFF
--- a/resources/lib/download.py
+++ b/resources/lib/download.py
@@ -316,7 +316,7 @@ def auto_download(type, artist_list, background=False):
                     art = remote_banner_list(auto_art)
                 else:
                     art = remote_artistthumb_list(auto_art)
-                if art:
+                if art or arthd:
                     if type == "fanart":
                         temp_art["path"] = path
                         auto_art["path"] = os.path.join(path, "extrafanart").replace("\\\\", "\\")


### PR DESCRIPTION
I think that fanart.tv doesn't support Clearlogos anymore. So newer artists only have HDClearlogos. And therefore the script skips the artist when auto downloading logos because the `art` attribute is empty in this case. With this little addition to the if clause the script was able to download all logos properly again.